### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ meetup-group: owasp-chandigarh-chapter
 
 ---
 ## Welcome
-OWASP Chandigarh is the Chandigarh chapter of "OWASP – Open Web Application Security Project", a community focused on building a knowledge-sharing platform for cybersecurity enthusiasts. The chapter brings together professionals, students, and hobbyists passionate about ethical hacking, information security, and cybersecurity.
+OWASP Chandigarh is the Chandigarh chapter of "OWASP – Open Worldwide Application Security Project", a community focused on building a knowledge-sharing platform for cybersecurity enthusiasts. The chapter brings together professionals, students, and hobbyists passionate about ethical hacking, information security, and cybersecurity.
 
 OWASP Chandigarh hosts regular meetups, workshops, and hands-on sessions that focus on real-world security issues, vulnerabilities, and attack-defense techniques. It serves as a collaborative space for members to learn, exchange ideas, and improve their cybersecurity skills, while fostering a culture of responsible security practices
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)
- BlueSky: [arkid15r.com](https://bsky.app/profile/arkid15r.com)